### PR TITLE
hide chrome on ?embedded=1

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -20,6 +20,17 @@ function hashLinkHandler(e) {
   }
 }
 
+// https://stackoverflow.com/a/901144
+function getParameterByName(name, url) {
+    if (!url) url = window.location.href;
+    name = name.replace(/[\[\]]/g, "\\$&");
+    var regex = new RegExp("[?&]" + name + "(=([^&#]*)|&|#|$)"),
+        results = regex.exec(url);
+    if (!results) return null;
+    if (!results[2]) return '';
+    return decodeURIComponent(results[2].replace(/\+/g, " "));
+}
+
 $(document).ready(function() {
   $(document).foundation();
 
@@ -45,5 +56,12 @@ $(document).ready(function() {
   if (userId === 'true') {
     $('.js-show-if-logged-out').addClass('hide');
     $('.js-show-if-logged-in').removeClass('hide');
+  }
+
+  var embedded = (getParameterByName('embedded') == '1');
+  if (embedded) {
+    $('.main-wrapper > nav').hide();
+    $('.main-wrapper > footer').hide();
+    $('body').css('padding-top', 0);
   }
 });


### PR DESCRIPTION
For use in bebo-mobile, allowing a webView to be used without injecting Javascript or using tight coupling.